### PR TITLE
Prevent including pre-compiled files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,10 @@ const onStyleResolve = async (build: PluginBuild, args: OnResolveArgs): Promise<
   }
 
   const fullPath = result.path
-
+  // Check for pre compiled JS files like file.css.js
+  if (!styleFilter.test(fullPath)) {
+    return;
+  }
   if (namespace === LOAD_STYLE_NAMESPACE) {
     return {
       path: fullPath,


### PR DESCRIPTION
Hey there,

hope you are still active maintainer :D

Currently it's not possible to compile @fluentui/react package with any style plugin. From the esbuild thread https://github.com/evanw/esbuild/issues/1834 it is mentioned the plugins should take care of properly selecting the files to compile. Thus I added 3 simple lines of code which will prevent inclusion of those precompiled files. In the example of fluentui there is for instance the import for BasePicker.less which indeed exists but it will instead picked the pre-compiled BasePicker.less.js.
Every esbuild style plugin tries to compile these JS files with less or what ever. So the condition just makes sure the resolved file is really a style.