### PR TITLE
Bugfix: Add `kind: args.kind` to build.resolve options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ const onStyleResolve = async (build: PluginBuild, args: OnResolveArgs): Promise<
 
   if (args.pluginData === SKIP_RESOLVE || namespace === LOAD_STYLE_NAMESPACE || namespace === LOAD_TEMP_NAMESPACE) return
 
-  const result = await build.resolve(args.path, { resolveDir: args.resolveDir, pluginData: SKIP_RESOLVE })
+  const result = await build.resolve(args.path, { resolveDir: args.resolveDir, pluginData: SKIP_RESOLVE, kind: args.kind })
   if (result.errors.length > 0) {
     return { errors: result.errors }
   }


### PR DESCRIPTION
`kind` option is required at esbuild@0.16.0.

As mentioned in [esbuild@0.16.0 release notes](https://github.com/evanw/esbuild/releases/tag/v0.16.0) :
> One additional consequence of this change is that the kind parameter is now required when calling the resolve() function in esbuild's plugin API. Previously the kind parameter defaulted to entry-point, but that no longer interacts with external so it didn't seem wise for this to continue to be the default. You now have to specify kind so that the path resolution mode is explicit.

Without this option, build may fail: `Must specify "kind" when calling "resolve"`

![image](https://user-images.githubusercontent.com/75289510/206860108-e44f6462-dfbd-4745-83c7-17510fe7e36b.png)
![image](https://user-images.githubusercontent.com/75289510/206860112-0aee41fa-7077-461c-b44e-ea0a2ef00bd6.png)
