### PR TITLE
Fix the garbled path problem caused by temporary CSS files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,10 @@ const handleCSSModules = (mapping: { data: any }, cssModulesOptions: CssModulesO
 }
 
 const onTempStyleResolve = async (build: PluginBuild, args: OnResolveArgs): Promise<OnResolveResult> => {
-  const { path, pluginData, resolveDir } = args
+  const { importer, pluginData, resolveDir } = args
 
   return {
-    path: path,
+    path: path.relative(build.initialOptions.absWorkingDir||'', importer),
     namespace: LOAD_TEMP_NAMESPACE,
     pluginData: { contents: pluginData, resolveDir }
   }
@@ -116,7 +116,7 @@ const onStyleLoad = (options: PluginOptions) => async (args: OnLoadArgs): Promis
   }
 
   if (extract) {
-    // Bundle css into inline base64url 
+    // Bundle css into inline base64url
     contents += `import ${JSON.stringify('ni:sha-256;'+createHash('sha256').update(css).digest('base64url'))};`
   }
 


### PR DESCRIPTION
Previously, we used temporary paths like ` import ni:sha256;xxxx` . Now it has been changed to the real import path, which facilitates the generation of CSS content. Esbuild will automatically generate path annotations, making it look more aesthetically pleasing.

**BEFORE：**
<img width="902" alt="image" src="https://github.com/g45t345rt/esbuild-style-plugin/assets/4987317/aba69d87-f1ce-4084-94d3-a737b83c182c">

**AFTER：**
<img width="552" alt="image" src="https://github.com/g45t345rt/esbuild-style-plugin/assets/4987317/f30ce9a9-0034-48c8-b223-c34e4d74e538">

PS：Other people have also mentioned related needs. https://github.com/g45t345rt/esbuild-style-plugin/pull/14#issuecomment-1721228546

Another issue is that base64url encoding was only added after node V15.3, so running on versions before this will result in garbled text. As I mentioned above, esbuild will write the path as a comment in compression mode. The garbled path is written into the CSS, affecting the encoding of the CSS file.

<img width="1036" alt="image" src="https://github.com/g45t345rt/esbuild-style-plugin/assets/4987317/80a64439-04e3-45d9-8e17-68ff1ab04220">

Although the two have no direct relationship, this can enhance the compatibility of this JavaScript library and allow it to run on lower versions of Node.